### PR TITLE
fix: image name casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,17 @@ volumes:
 ### Prerequisites
 Install Docker on your machine. An easy way to do this is by using [Docker Desktop](https://docs.docker.com/get-docker/), but you could also use [other tools or methods](https://docs.docker.com/engine/install/).
 
+#### Log in to the GitHub Container Registry (required for deployment)
+To be able to pull images from GitHubs container registry (where the official squire images reside), you need to log in using your GitHub account.
+
+You can find a detailed guide on how to do this [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
+
+The TL;DR is:
+Create a personal access token with the `read:packages` scope on https://github.com/settings/tokens and use it to log into the GitHub Container Registry with the following command:
+```
+echo YOUR_TOKEN | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+```
+
 ### Deployment
 
 Choose one of the following, depending on your use case.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     networks:
       - internal
   frontend:
-    image: ghcr.io/shaneherd/SquireWorkshop-frontend:1.0.0
+    image: ghcr.io/shaneherd/squireworkshop-frontend:1.0.0
     depends_on:
       - backend
     container_name: 'Squire-Frontend'
@@ -29,7 +29,7 @@ services:
     networks:
       - internal
   backend:
-    image: ghcr.io/shaneherd/SquireWorkshop-backend:1.0.0
+    image: ghcr.io/shaneherd/squireworkshop-backend:1.0.0
     extends:
       file: docker-compose.config.yml
       service: backend
@@ -53,7 +53,7 @@ services:
     networks:
       - internal
   database:
-    image: ghcr.io/shaneherd/SquireWorkshop-database:1.0.0
+    image: ghcr.io/shaneherd/squireworkshop-database:1.0.0
     extends:
       file: docker-compose.config.yml
       service: database


### PR DESCRIPTION
also update docs to explain GitHub Container Registry authentification, which is needed.