### PR TITLE
chore: update example image versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     networks:
       - internal
   frontend:
-    image: ghcr.io/shaneherd/squireworkshop-frontend:1.0.0
+    image: ghcr.io/shaneherd/squireworkshop-frontend
     depends_on:
       - backend
     container_name: 'Squire-Frontend'
@@ -29,7 +29,7 @@ services:
     networks:
       - internal
   backend:
-    image: ghcr.io/shaneherd/squireworkshop-backend:1.0.0
+    image: ghcr.io/shaneherd/squireworkshop-backend
     extends:
       file: docker-compose.config.yml
       service: backend
@@ -53,7 +53,7 @@ services:
     networks:
       - internal
   database:
-    image: ghcr.io/shaneherd/squireworkshop-database:1.0.0
+    image: ghcr.io/shaneherd/squireworkshop-database
     extends:
       file: docker-compose.config.yml
       service: database


### PR DESCRIPTION
don't pin version as this is an example, and this makes it so that we don't need to update it on every release

If more experienced users want to pin an exact version, they can of course still do that